### PR TITLE
Replaced Extension::applyFunc by utility::apply.

### DIFF
--- a/include/rencpp/common.hpp
+++ b/include/rencpp/common.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <limits>
 #include <stdexcept>
+#include <tuple>
 
 
 // http://stackoverflow.com/a/4030983/211160
@@ -139,6 +140,25 @@ struct gens<0, S...> {
 };
 
 
+
+///
+/// Apply function to tuples (clone of std::apply)
+///
+
+template<typename Func, typename Tuple, std::size_t... Indices>
+auto apply_impl(Func&& func, Tuple&& args, indices<Indices...>)
+    -> decltype(std::forward<Func>(func)(std::get<Indices>(std::forward<Tuple>(args))...))
+{
+    return std::forward<Func>(func)(std::get<Indices>(std::forward<Tuple>(args))...);
+}
+
+template<typename Func, typename Tuple,
+         typename Indices = make_indices<std::tuple_size<Tuple>::value>>
+auto apply(Func&& func, Tuple&& args)
+    -> decltype(apply_impl(std::forward<Func>(func), std::forward<Tuple>(args), Indices{}))
+{
+    return apply_impl(std::forward<Func>(func), std::forward<Tuple>(args), Indices{});
+}
 
 ///
 /// MORE FREAKY MAGIC

--- a/include/rencpp/extension.hpp
+++ b/include/rencpp/extension.hpp
@@ -77,14 +77,6 @@ private:
     > table;
 
 public:
-    template<int ...S>
-    static R callFunc(
-        FunType const & fun,
-        ParamsType const & params,
-        utility::seq<S...>
-    ) {
-        return fun(std::get<S>(params) ...);
-    }
 
     template <typename A>
     static std::tuple<A> params(Engine & engine, RenCell * cell)
@@ -127,10 +119,9 @@ public:
                 size_t & N = std::get<1>(entry);
                 FunType const & fun = std::get<2>(entry);
 
-                R result = callFunc(
+                auto&& result = utility::apply(
                     fun,
-                    params<Ts...>(engine, ds),
-                    typename utility::gens<sizeof...(Ts)>::type()
+                    params<Ts...>(engine, ds)
                 );
 
                 // Like R_RET in a native function


### PR DESCRIPTION
I added a C++11 equivalent of std::apply (proposed for C++17) to have a more generic mechanism to replace Extension::callFunc.
