### PR TITLE
Static dispatch

### DIFF
--- a/include/rencpp/common.hpp
+++ b/include/rencpp/common.hpp
@@ -158,6 +158,29 @@ auto apply(Func && func, Tuple && args)
 }
 
 
+
+///
+/// PARAMETER PACKS MANIPULATION
+///
+
+//
+// This is a clone of the proposed std::type_at
+//
+
+template <unsigned N, typename T, typename... R>
+struct type_at
+{
+    using type = typename type_at<N-1, R...>::type;
+};
+
+template <typename T, typename... R>
+struct type_at<0, T, R...>
+{
+    using type = T;
+};
+
+
+
 } // end namespace utility
 
 } // end namespace ren


### PR DESCRIPTION
Replaced utility::apply(fun, params<Ts...>(engine, ds)) by applyFunc(fun, engine, ds). This new function is strongly coupled to Extension itself but allows to replace the runtime loop in params by a comile-time dispatch. It also adds a new helper class type_at<> to perform even more template wizardry.
