### PR TITLE
Template nitpicks

### DIFF
--- a/include/rencpp/common.hpp
+++ b/include/rencpp/common.hpp
@@ -5,7 +5,7 @@
 #include <cstddef>
 #include <limits>
 #include <stdexcept>
-#include <tuple>
+#include <type_traits>
 
 
 // http://stackoverflow.com/a/4030983/211160
@@ -60,7 +60,7 @@ inline T * evilMutablePointerCast(T const * somePointer) {
 
 
 ///
-/// HELPERS FOR MAGIC USED IN EXTENSION.HPP
+/// COMPILE TIME INTEGER SEQUENCES
 ///
 
 
@@ -81,6 +81,36 @@ struct make_indices<0, Ind...>:
     indices<Ind...>
 {};
 
+
+
+///
+/// PARAMETER PACKS MANIPULATION
+///
+
+//
+// This is a clone of the proposed std::type_at
+//
+
+template <unsigned N, typename T, typename... R>
+struct type_at
+{
+    using type = typename type_at<N-1, R...>::type;
+};
+
+template <typename T, typename... R>
+struct type_at<0, T, R...>
+{
+    using type = T;
+};
+
+
+
+///
+/// FUNCTION TRAITS
+///
+
+
+
 template<typename T>
 struct function_traits:
     function_traits<decltype(&T::operator())>
@@ -94,7 +124,7 @@ struct function_traits<Ret(C::*)(Args...) const>
     using result_type = Ret;
 
     template<std::size_t N>
-    using arg = typename std::tuple_element<N, std::tuple<Args...>>::type;
+    using arg = typename type_at<N, Args...>::type;
 };
 
 
@@ -139,28 +169,6 @@ auto apply(Func && func, Tuple && args)
         Indices {}
     );
 }
-
-
-
-///
-/// PARAMETER PACKS MANIPULATION
-///
-
-//
-// This is a clone of the proposed std::type_at
-//
-
-template <unsigned N, typename T, typename... R>
-struct type_at
-{
-    using type = typename type_at<N-1, R...>::type;
-};
-
-template <typename T, typename... R>
-struct type_at<0, T, R...>
-{
-    using type = T;
-};
 
 
 

--- a/include/rencpp/printer.hpp
+++ b/include/rencpp/printer.hpp
@@ -24,7 +24,7 @@
 //
 //     ren::print.only("This", "won't", "be", "spaced");
 //
-// Since this is only an experiment, and being used to try and make 
+// Since this is only an experiment, and being used to try and make
 // debugging more natural and faster... it flushes lines with std::endl.
 // The risk of the experiment is that it might wind up being a
 // reimplementation on the C++ side and not do *exactly* what the internal
@@ -44,34 +44,34 @@ public:
     }
 
     template <typename T>
-    void writeArgs(bool spaced, T const & t) {
+    void writeArgs(bool spaced, T && t) {
         UNUSED(spaced);
-        dest << t;
+        dest << std::forward<T>(t);
     }
 
     template <typename T, typename... Ts>
-    void writeArgs(bool spaced, T const & t, Ts const &... args) {
-        writeArgs(spaced, t);
+    void writeArgs(bool spaced, T && t, Ts &&... args) {
+        writeArgs(spaced, std::forward<T>(t));
         if (spaced)
             dest << " ";
-        writeArgs(spaced, args...);
+        writeArgs(spaced, std::forward<Ts>(args)...);
     }
 
     template <typename... Ts>
-    void corePrint(bool spaced, bool linefeed, Ts const &... args) {
-        writeArgs(spaced, args...);
+    void corePrint(bool spaced, bool linefeed, Ts &&... args) {
+        writeArgs(spaced, std::forward<Ts>(args)...);
         if (linefeed)
             dest << std::endl;
     }
 
     template <typename... Ts>
-    void operator()(Ts const &... args) {
-        corePrint(true, true, args...);
+    void operator()(Ts &&... args) {
+        corePrint(true, true, std::forward<Ts>(args)...);
     }
 
     template <typename... Ts>
-    void only(Ts const &... args) {
-        corePrint(false, false, args...);
+    void only(Ts &&... args) {
+        corePrint(false, false, std::forward<Ts>(args)...);
     }
 
     ~Printer () {


### PR DESCRIPTION
Two commits here: the first one removes the need of the header <tuple> in common.hpp and adds the missing <type_traits>. The second one replaces const references by forwarding references in the printing functions. The overloads of operator<< are not supposed to modify their parameters, therefore, the const references were ok. However, if an operator<< also has a faster overload with rvalue references, calling it instead may result in better performance. The perfect forwarding, as implement, will always pick the most suitable overload, so it does not remove any correctness and may freely take advantage of rvalue-references overloads.
