### PR TITLE
Bind signalHandler to SIGHUP only if it exists.

### DIFF
--- a/src/rebol-binding/rebol-runtime.cpp
+++ b/src/rebol-binding/rebol-runtime.cpp
@@ -247,7 +247,9 @@ bool RebolRuntime::lazyInitializeIfNecessary() {
     };
 
     signal(SIGINT, signalHandler);
+#ifdef SIGHUP
     signal(SIGHUP, signalHandler);
+#endif
     signal(SIGTERM, signalHandler);
 
     // Initialize the REBOL library (reb-lib):


### PR DESCRIPTION
SIGHUP is an Unix-specifix signal. Fortunately, signal names are required to be macros, even in C++, so we can directly #ifdef SIGHUP.
