### PR TITLE
Fix static_assert and kill UNUSED.

### DIFF
--- a/include/rencpp/common.hpp
+++ b/include/rencpp/common.hpp
@@ -56,7 +56,7 @@
 #if (REN_CLASSLIB_STD == 0) and (REN_CLASSLIB_QT == 0)
 
     static_assert(false, "Unimplemented feature: no REN_CLASSLIB set"
-        " see https://github.com/hostilefork/rencpp/issues/22"
+        " see https://github.com/hostilefork/rencpp/issues/22");
 
 #endif
 

--- a/include/rencpp/common.hpp
+++ b/include/rencpp/common.hpp
@@ -8,15 +8,6 @@
 #include <type_traits>
 
 
-// http://stackoverflow.com/a/4030983/211160
-// Use to indicate a variable is being intentionally not referred to (which
-// usually generates a compiler warning)
-
-#ifndef UNUSED
-  #define UNUSED(x) ((void)(true ? 0 : ((x), void(), 0)))
-#endif
-
-
 
 ///
 /// CLASSLIB LIBRAY INCLUSIONS

--- a/include/rencpp/runtime.hpp
+++ b/include/rencpp/runtime.hpp
@@ -162,8 +162,7 @@ public:
     }
 
     template <typename T>
-    void writeArgs(bool spaced, T && t) {
-        UNUSED(spaced);
+    void writeArgs(bool , T && t) {
         runtime.getOutputStream() << std::forward<T>(t);
     }
 

--- a/src/rebol-binding/rebol-hooks.cpp
+++ b/src/rebol-binding/rebol-hooks.cpp
@@ -369,8 +369,6 @@ public:
         REBVAL * constructOutDatatypeIn,
         REBVAL * applyOut
     ) {
-        UNUSED(engine);
-
         lazyThreadInitializeIfNeeded(engine);
 
         REBOL_STATE state;
@@ -581,8 +579,6 @@ public:
                 if (nodes[engine.data].empty())
                     nodes.erase(engine.data);
             }
-        #else
-            UNUSED(engine);
         #endif
 
             current += sizeofCellBlock;

--- a/src/rebol-binding/rebol-runtime.cpp
+++ b/src/rebol-binding/rebol-runtime.cpp
@@ -75,14 +75,12 @@ void Host_Crash(REBYTE * message) {
 //
 
 
-RebolRuntime::RebolRuntime (bool someExtraInitFlag) :
+RebolRuntime::RebolRuntime (bool) :
     Runtime (),
     initialized (false),
     osPtr (&std::cout),
     isPtr (&std::cin)
 {
-    UNUSED(someExtraInitFlag);
-
     Host_Lib = &Host_Lib_Init; // OS host library (dispatch table)
 
     // We don't want to rewrite the entire host lib here, but we can
@@ -233,8 +231,7 @@ bool RebolRuntime::lazyInitializeIfNecessary() {
     // to handle a Ctrl-C on the gui thread during an infinite loop you need
     // to be doing the evaluation on a worker thread and signal it from GUI
 
-    auto signalHandler = [](int sig) {
-        UNUSED(sig);
+    auto signalHandler = [](int) {
         std::cout << "[escape]";
         SET_SIGNAL(SIG_ESCAPE);
     };

--- a/src/rebol-binding/rebol-stdio.cpp
+++ b/src/rebol-binding/rebol-stdio.cpp
@@ -175,14 +175,12 @@ extern REBDEV *Devices[];
 
 /***********************************************************************
 **
-*/	static DEVICE_CMD Open_Echo(REBREQ *req)
+*/	static DEVICE_CMD Open_Echo(REBREQ *)
 /*
 **		Open a file for low-level console echo (output).
 **
 ***********************************************************************/
 {
-    UNUSED(req);
-
     throw std::runtime_error(
         "echo stdin and stdout to file not supported by binding"
         " in a direct fashion, you have to create a stream aggregator"


### PR DESCRIPTION
UNUSED was supposed to shut warnings but triggered other warnings rendering it kind of useless. Warnings about unused parameters are now eliminated by simply not writing the name of the parameter.
