### PR TITLE
Kill typedef. Use C++11 type alias instead.

### DIFF
--- a/include/rencpp/context.hpp
+++ b/include/rencpp/context.hpp
@@ -41,7 +41,7 @@ class Engine;
 
 class Context {
 public:
-    typedef std::function<Context & (Engine *)> Finder;
+    using Finder = std::function<Context & (Engine *)>;
 
 private:
     friend class Value;

--- a/include/rencpp/engine.hpp
+++ b/include/rencpp/engine.hpp
@@ -50,7 +50,7 @@ namespace ren {
 
 class Engine {
 public:
-    typedef std::function<Engine&()> Finder;
+    using Finder = std::function<Engine&()>;
 
 private:
     friend class Value;

--- a/include/rencpp/extension.hpp
+++ b/include/rencpp/extension.hpp
@@ -73,11 +73,11 @@ namespace internal {
 
 extern std::mutex extensionTablesMutex;
 
-typedef int RenShimId;
+using RenShimId = int;
 
 extern RenShimId shimIdToCapture;
 
-typedef RenResult (* RenShimBouncer)(RenShimId id, RenCell * stack);
+using RenShimBouncer = RenResult (*)(RenShimId id, RenCell * stack);
 
 extern RenShimBouncer shimBouncerToCapture;
 
@@ -102,9 +102,9 @@ private:
     // examining the type signature, so that it can call the C++ hook.
     //
 
-    typedef std::function<R(Ts...)> FunType;
+    using FunType = std::function<R(Ts...)>;
 
-    typedef std::tuple<Ts...> ParamsType;
+    using ParamsType = std::tuple<Ts...>;
 
 
     // When a "self-aware" shim forwards its parameter and its function
@@ -330,14 +330,14 @@ Function makeFunction_(
     Fun && fun,
     utility::indices<Ind...>
 ) {
-    typedef internal::FunctionGenerator<
+    using Gen = internal::FunctionGenerator<
         typename utility::function_traits<
             typename std::remove_reference<Fun>::type
         >::result_type,
         typename utility::function_traits<
             typename std::remove_reference<Fun>::type
         >::template arg<Ind>...
-    > Gen;
+    >;
 
     using Ret = typename utility::function_traits<
         typename std::remove_reference<Fun>::type

--- a/include/rencpp/values.hpp
+++ b/include/rencpp/values.hpp
@@ -168,7 +168,7 @@ public: // temporary for the lambda in function, find better way
     // the plus side: copying that value around won't make any more of them,
     // and non-series values don't have them at all.
     //
-    typedef std::atomic<unsigned int> RefcountType;
+    using RefcountType = std::atomic<unsigned int>;
     RefcountType * refcountPtr;
 
     //


### PR DESCRIPTION
I felt that killing typedef everywhere (except in hooks.hpp since it looks like it should be C-compatible) and replacing it by the new type alias would be more consistent (since it's already used) and would improve readability. It's kind of subjective, but I always found typedef of function pointer types kind of hard to read for example. Fell free to merge or not.
