### PR TITLE
Simplified use of std::enable_if in template parameters.

### DIFF
--- a/include/rencpp/values.hpp
+++ b/include/rencpp/values.hpp
@@ -251,7 +251,7 @@ protected:
     template<
         class T,
         typename = typename std::enable_if<
-            std::is_base_of<Value, T>::value, void *
+            std::is_base_of<Value, T>::value
         >::type
     >
     static T construct (Dont const &) {
@@ -279,7 +279,7 @@ protected:
     template<
         class T,
         typename = typename std::enable_if<
-            std::is_base_of<Value, T>::value, void *
+            std::is_base_of<Value, T>::value
         >::type
     >
     static T construct (RenEngineHandle engine, RenCell const & cell) {
@@ -598,8 +598,7 @@ public:
         class T,
         typename = typename std::enable_if<
             std::is_base_of<Value, T>::value
-            and not std::is_same<Value, T>::value,
-            T
+            and not std::is_same<Value, T>::value
         >::type
     >
     explicit operator T () const


### PR DESCRIPTION
I removed the second parameter everywhere std::enable_if is used. This parameter is only useful when std::enable_if is used for the parameters or the return type of a function. Since, in our case, it is only used in default parameters and thus useless, I let it default to void (which is the default second template parameter of std::enable_if).
