### PR TITLE
Windows hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ add_cxx_flags("-Wstrict-overflow=5")
 add_cxx_flags("-Wswitch-default")
 add_cxx_flags("-Wundef")
 add_cxx_flags("-Werror")
+add_cxx_flags("-Wno-unknown-pragmas")
 add_cxx_flags("-Wno-unused")
 add_cxx_flags("-pedantic")
 add_cxx_flags("-Wold-style-cast")
@@ -375,6 +376,7 @@ elseif(RUNTIME STREQUAL "rebol")
     remove_cxx_flag("-Wold-style-cast")
     remove_cxx_flag("-Wsign-conversion")
     remove_cxx_flag("-Wcast-align")
+    remove_cxx_flag("-Wcast-qual")
 
     # Add any extra includes for the project browser
 
@@ -389,7 +391,16 @@ elseif(RUNTIME STREQUAL "rebol")
     # It's important to make sure you're set to the right platform, as it
     # affects endianness and other things.
 
-    add_definitions(-DTO_LINUX)
+    if(WIN32)
+
+        add_definitions(-DTO_WIN32)
+        add_definitions(-DUNICODE)
+
+    else()
+
+        add_definitions(-DTO_LINUX)
+
+    endif()
 
     # Try and get all the guts out of the Rebol Core executable to
     # include in the binding.  Take out the main and Host_Lib

--- a/src/rebol-binding/rebol-hooks.cpp
+++ b/src/rebol-binding/rebol-hooks.cpp
@@ -18,6 +18,15 @@ extern "C" {
 extern jmp_buf * Halt_State;
 void Init_Task_Context();	// Special REBOL values per task
 
+#ifdef TO_WIN32
+    #include <windows.h>
+    // The objects file from Rebol linked into RenCpp need a
+    // variable named App_Instance for the linkage to work when
+    // built for Windows. Therefore, we provided this variable
+    // here. It does not serve any other purpose.
+    HINSTANCE App_Instance = 0;
+#endif
+
 }
 
 

--- a/src/rebol-binding/rebol-runtime.cpp
+++ b/src/rebol-binding/rebol-runtime.cpp
@@ -187,11 +187,19 @@ bool RebolRuntime::lazyInitializeIfNecessary() {
     // don't have a way to give you the executable's path if we are
     // a binding"
 
-    REBCHR fakeArgv0 []
-        = "/dev/null/rencpp-binding/look-at/rebol-hooks.cpp";
+    #ifdef TO_WIN32
+        REBCHR * fakeArgv0
+            = (REBCHR*) L"/dev/null/rencpp-binding/look-at/rebol-hooks.cpp";
 
-    REBCHR argvQuiet []
-        = "--quiet";
+        REBCHR * argvQuiet
+            = (REBCHR*) L"--quiet";
+    #else
+        REBCHR fakeArgv0 []
+            = "/dev/null/rencpp-binding/look-at/rebol-hooks.cpp";
+
+        REBCHR argvQuiet []
+            = L"--quiet";
+    #endif
 
     // Theoretically we could offer hooks for this deferred initialization
     // to pass something here, or even change it while running.  Right


### PR DESCRIPTION
Added some changes from @earl to make RenCpp Windows-compatible to the source code and to the CMakeLists.txt. Now it _should_ work with both Linux and Windows. I only tried it with MinGW though (and had to add some MinGW-specific libraries locally, will investigate further); I have no idea whether it works with Microsoft Visual Studio.
