### PR TITLE
Windows hooks again.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,6 +451,14 @@ elseif(RUNTIME STREQUAL "rebol")
 
     set(LIBS_ALL ${LIBS_ALL} ${CMAKE_DL_LIBS})
 
+    if(WIN32)
+
+        # Rebol depends on Winsocks when built on Windows.
+
+        set(LIBS_ALL ${LIBS_ALL} ws2_32)
+
+    endif()
+
 else()
 
     message(FATAL_ERROR "Invalid Runtime Specified (not none, red, rebol)")


### PR DESCRIPTION
Here is what I mentioned in my previous pull request: the examples need to be linked with Winsocks to work on Windows when Rebol is used. I tweaked the makefile to automatically link the whole stuff to Winsocks when we are compiling for Windows. If works for MinGW but, from what I have read, it should also work for MSVC (if the rest of RenCpp works with MSVC of course).
