### PR TITLE
Fixed std::initializer_list-related bug with GCC.

### DIFF
--- a/include/rencpp/values.hpp
+++ b/include/rencpp/values.hpp
@@ -572,11 +572,11 @@ public:
 
     template <typename... Ts>
     inline Value apply(Ts const &... args) const {
-        return apply(std::initializer_list<internal::Loadable>{args...});
+        return apply({ args... });
     }
 
     template <typename... Ts>
-    inline Value operator()(Ts... args) const {
+    inline Value operator()(Ts&&... args) const {
         return apply(std::forward<Ts>(args)...);
     }
 


### PR DESCRIPTION
This commit fixes two things:
- First add `&&` to `Ts...` in `apply`. `std::forward` only works well with forwarding references. Until there, it was performing a copy instead.
- The variadic version of `apply` was meant to forward its arguments to the `std::initializer_list` one. Unfortunately, it was instead creating an `std::initializer_list` and passing it to the appropriate overload of `appy`. Copying an `std::initializer_list` is undefined behaviour and shouldn't be allowed in future versions of the standard.
