### PR TITLE
Small correctness and iodiomacy improvements

### DIFF
--- a/include/rencpp/values.hpp
+++ b/include/rencpp/values.hpp
@@ -1002,24 +1002,24 @@ public:
 
     public:
         iterator & operator++() {
-            state++;
+            ++state;
             return *this;
         }
 
         iterator & operator--() {
-            state--;
+            --state;
             return *this;
         }
 
         iterator operator++(int) {
             auto temp = *this;
-            ++*this;
+            operator++();
             return temp;
         }
 
         iterator operator--(int) {
             auto temp = *this;
-            --*this;
+            operator--();
             return temp;
         }
 
@@ -1108,24 +1108,24 @@ public:
 
     public:
         iterator & operator++() {
-            state++;
+            ++state;
             return *this;
         }
 
         iterator & operator--() {
-            state--;
+            --state;
             return *this;
         }
 
         iterator operator++(int) {
             auto temp = *this;
-            ++*this;
+            operator++();
             return temp;
         }
 
         iterator operator--(int) {
             auto temp = *this;
-            --*this;
+            operator--();
             return temp;
         }
 

--- a/include/rencpp/values.hpp
+++ b/include/rencpp/values.hpp
@@ -1023,9 +1023,9 @@ public:
             return temp;
         }
 
-        bool operator==(iterator const & other)
+        bool operator==(iterator const & other) const
             { return state.isSameAs(other.state); }
-        bool operator!=(iterator const & other)
+        bool operator!=(iterator const & other) const
             { return not state.isSameAs(other.state); }
 
         Value operator * () const { return *state; }
@@ -1129,9 +1129,9 @@ public:
             return temp;
         }
 
-        bool operator==(iterator const & other)
+        bool operator==(iterator const & other) const
             { return state.isSameAs(other.state); }
-        bool operator!=(iterator const & other)
+        bool operator!=(iterator const & other) const
             { return not state.isSameAs(other.state); }
 
         Character operator * () const {

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -52,7 +52,7 @@ Value::operator bool() const {
         (*this)();
         UNREACHABLE_CODE();
     }
-    return (not isNone()) and (not isFalse());
+    return not (isNone() or isFalse());
 }
 
 


### PR DESCRIPTION
Three small things:
- More idiomatic `operator++`/`operator--` for iterators (_may_ also be faster).
- `const` for `operator==`/`operator!=` in iterators.
- De Morgan's laws for fun and profit.
