### PR TITLE
Fix issue about implicit conversions to ren::Logic.

### DIFF
--- a/include/rencpp/common.hpp
+++ b/include/rencpp/common.hpp
@@ -196,6 +196,39 @@ struct function_traits<Ret(C::*)(Args...) const>
 };
 
 
+
+///
+/// SAFE BOOL CLASS
+///
+
+//
+// This is a little bit different from the "safe bool idiom"
+// used in the pre-C++11 era. This class allows some level of
+// trickery so that classes can be implicitly constructed from
+// bool but not implicitly constructed from type that can be
+// implicitly converted to bool.
+//
+
+class safe_bool {
+private:
+    bool value;
+
+public:
+    explicit constexpr safe_bool(bool value) :
+        value (value)
+    {
+    }
+
+    // This class can only be constructed from bool
+    template <typename T>
+    safe_bool(T) = delete;
+
+    explicit constexpr operator bool () const {
+        return value;
+    }
+};
+
+
 } // end namespace utility
 
 } // end namespace ren

--- a/include/rencpp/values.hpp
+++ b/include/rencpp/values.hpp
@@ -749,10 +749,20 @@ protected:
     inline bool isValid() const { return isLogic(); }
 
 public:
-    // Narrow the construction?
-    // https://github.com/hostilefork/rencpp/issues/24
-    Logic (bool const & b, Engine * engine = nullptr) :
+    explicit Logic (bool const & b, Engine * engine = nullptr) :
         Value (b, engine)
+    {
+    }
+
+    // Trick so that Logic can be implicitly constructed from
+    // bool but not from a type implicitly convertible to bool.
+    //
+    //     https://github.com/hostilefork/rencpp/issues/24
+    //
+
+    template <typename T>
+    Logic (const T & value, Engine * engine = nullptr) :
+        Logic (bool(utility::safe_bool(value)), engine)
     {
     }
 


### PR DESCRIPTION
This should solve issue #24 without introducing new errors. The only problem I see is that `Logic` is now only implicitly constructible from `bool` and not from boolean proxies (it doesn't matter for now, but the issue may rise in a near or far future).
