### PR TITLE
Make Ren Garden work with more keyboard layouts.

### DIFF
--- a/examples/workbench/replpad.cpp
+++ b/examples/workbench/replpad.cpp
@@ -999,15 +999,6 @@ void ReplPad::keyPressEvent(QKeyEvent * event) {
         return;
     }
 
-    if (ctrled) {
-        // For whatever reason, the usual behavior in widgets is to go ahead
-        // and consider hitting something like "control backslash" to mean
-        // the same thing as backslash.  We throw these out if they made
-        // it this far without special handling.
-
-        return;
-    }
-
     textCursor().insertText(event->text());
 }
 


### PR DESCRIPTION
Ren Garden did not work with some keyboards (AZERTY in my case) where the key AltGr is needed to input special characters. AltGr being considered as Ctrl+Alt by Qt, I had to remove one hook to make it work. We will trust `hasRealText` to discriminate good from bad inputs even if it might have some unexpected consequences in some corner cases. That's the price for internationalization.
