### PR TITLE
Curly braces to construct nested blocks.

### DIFF
--- a/include/rencpp/values.hpp
+++ b/include/rencpp/values.hpp
@@ -1399,11 +1399,15 @@ public:
 
     // Constructor inheritance does not inherit move or copy constructors
 
+    Loadable ();
+
     Loadable (Value const & value) : Value (value) {}
 
     Loadable (Value && value) : Value (value) {}
 
     Loadable (char const * source);
+
+    Loadable (std::initializer_list<Loadable> args);
 
 #if REN_CLASSLIB_STD == 1
     Loadable (std::string const & source) :

--- a/src/rebol-binding/rebol-runtime.cpp
+++ b/src/rebol-binding/rebol-runtime.cpp
@@ -22,6 +22,11 @@ RebolRuntime runtime {true};
 
 namespace internal {
 
+Loadable::Loadable () :
+    Loadable (Block {})
+{
+}
+
 Loadable::Loadable (char const * sourceCstr) :
     Value (Value::Dont::Initialize)
 {
@@ -31,6 +36,11 @@ Loadable::Loadable (char const * sourceCstr) :
 
     refcountPtr = nullptr;
     origin = REN_ENGINE_HANDLE_INVALID;
+}
+
+Loadable::Loadable (std::initializer_list<Loadable> loadables) :
+    Value (Block(loadables))
+{
 }
 
 } // end namespace internal


### PR DESCRIPTION
Improvement - to discuss later - so that `Block { {1, 2}, {true, 3} }` can actually be considered as a `Block { Block { Integer, Integer }, Block { Logic, Integer } }` minus the automatic downcast since it's not feasible in a statically typed language. In other worlds, we will have to teach that during a `Block` construction, unless a type is explicitly stated, a new pair of curly braces means a new `Block`.

This will allow to test issue #1 over and over before a final release.
