### PR TITLE
Enable 64-bit compilation of RenCpp

### DIFF
--- a/include/rencpp/common.hpp
+++ b/include/rencpp/common.hpp
@@ -71,44 +71,6 @@
 
 
 ///
-/// BRIDGES TO FIXED-SIZE CONVERSIONS
-///
-
-//
-// Although 64-bit builds of Rebol do exist, Red is currently focusing on
-// 32-bit architectures for the most part.  Hence there are some places
-// where pointers can't be used and need to be converted to.  Hopefully not
-// too many of these will creep in; but right now there are some by matter
-// of necessity and it's good to point them out.
-//
-
-static_assert(
-    sizeof(void *) == sizeof(int32_t),
-    "building rencpp binding with non 32-bit pointers..."
-    "see evilPointerToInt32Cast in include/rencpp/common.hpp"
-);
-
-static_assert(
-    sizeof(size_t) == sizeof(int32_t),
-    "building rencpp binding with non 32-bit size_t..."
-    "see remarks in include/rencpp/common.hpp"
-);
-
-inline int32_t evilPointerToInt32Cast(void const * somePointer) {
-    return reinterpret_cast<int32_t>(somePointer);
-}
-
-template<class T>
-inline T evilInt32ToPointerCast(int32_t someInt) {
-    static_assert(
-        std::is_pointer<T>::value,
-        "evilInt32ToPointer cast used on non-ptr"
-    );
-    return reinterpret_cast<T>(someInt);
-}
-
-
-///
 /// UNREACHABLE CODE MACRO
 ///
 

--- a/src/rebol-binding/rebol-hooks.cpp
+++ b/src/rebol-binding/rebol-hooks.cpp
@@ -410,7 +410,7 @@ public:
                 // get through transcode which returns [foo bar] and
                 // [[foo bar]] that discern the cases
 
-                auto loadText = reinterpret_cast<REBYTE*>(cell->data.integer);
+                auto loadText = reinterpret_cast<REBYTE*>(VAL_HANDLE(cell));
 
                 REBSER * transcoded = Scan_Source(
                     loadText, LEN_BYTES(loadText)

--- a/src/rebol-binding/rebol-runtime.cpp
+++ b/src/rebol-binding/rebol-runtime.cpp
@@ -33,7 +33,8 @@ Loadable::Loadable (char const * sourceCstr) :
 {
     // using REB_END as our "alien"
     VAL_SET(&cell, REB_END);
-    cell.data.integer = evilPointerToInt32Cast(sourceCstr);
+    VAL_HANDLE(&cell) =
+        reinterpret_cast<ANYFUNC>(const_cast<char *>(sourceCstr));
 
     refcountPtr = nullptr;
     origin = REN_ENGINE_HANDLE_INVALID;
@@ -118,12 +119,12 @@ RebolRuntime::RebolRuntime (bool) :
         bounds = STACK_BOUNDS;
 
 #ifdef OS_STACK_GROWS_UP
-    Stack_Limit = (REBCNT)(&marker) + bounds;
+    Stack_Limit = (uintptr_t)(&marker) + bounds;
 #else
-    if (bounds > (REBCNT)(&marker))
+    if (bounds > (uintptr_t)(&marker))
         Stack_Limit = 100;
     else
-        Stack_Limit = (REBCNT)(&marker) - bounds;
+        Stack_Limit = (uintptr_t)(&marker) - bounds;
 #endif
 
     // Rebytes, version numbers


### PR DESCRIPTION
- Store Loadable's source string inside a HANDLE Rebol value cell, which
  is always pointer sized.
- Remove the static asserts checking for 32-bit-ness.
- Adapt some casts taken from R3's internal to cast to a pointer-sized
  integer, instead of to the 32-bit wide "REBCNT" typedef.

With these changes, RenCpp builds successfully against either 32-bit R3
mainline sources (github.com/rebol/rebol) or 64-bit R3 rebolsource
sources (github.com/rebolsource/r3).
