### PR TITLE
Customizable behaviour for AnyBlock_ construction.

### DIFF
--- a/examples/block-test.cpp
+++ b/examples/block-test.cpp
@@ -23,4 +23,19 @@ int main(int, char **) {
 
     Block randomStuff {"blue", Block {true, 1020}, 3.04};
     print(randomStuff);
+
+    // More tests, waiting for the test suite
+
+    Block blk { {1, true}, {false, 2} };
+    std::cout << blk;
+    assert(blk.isBlock());
+    assert(blk[1].isBlock());
+    assert(blk[2].isBlock());
+
+    Block blk1 = static_cast<Block>(blk[1]);
+    Block blk2 = static_cast<Block>(blk[2]);
+    assert(blk1[1].isInteger());
+    assert(blk1[2].isLogic());
+    assert(blk2[1].isLogic());
+    assert(blk2[2].isInteger());
 }

--- a/src/rebol-binding/rebol-value.cpp
+++ b/src/rebol-binding/rebol-value.cpp
@@ -175,11 +175,6 @@ QString to_QString(Value const & value) {
 
 namespace internal {
 
-Loadable::Loadable () :
-    Loadable (Block {})
-{
-}
-
 Loadable::Loadable (char const * sourceCstr) :
     Value (Value::Dont::Initialize)
 {
@@ -190,11 +185,6 @@ Loadable::Loadable (char const * sourceCstr) :
 
     refcountPtr = nullptr;
     origin = REN_ENGINE_HANDLE_INVALID;
-}
-
-Loadable::Loadable (std::initializer_list<Loadable> loadables) :
-    Value (Block(loadables))
-{
 }
 
 


### PR DESCRIPTION
This branch adds some subtle changes to easily gives semantics to untyped curly braces in `Loadable`. Currently, it is done so that untyped curly braces during the construction of a `Block` construct a nested `Block` while by default, untyped curly braces in the construction of any other type deriving from `AnyBlock_` trigger a compile time error. Therefore, `Block { {1, 2}, {true, false}, {} }` is the same as `Block { Block {1, 2}, Block {true, false}, Block {} }` while `Paren { {1, 2}, {true, false}, {} }` is an error. It can be trivially changed by modifying the third template parameter of `AnyBlock_` to suit the needs.

I also added a couple of tests that ought to be moved to the test suite when it is created.

Anyway, this should definitely solve anything related to #1 and even if the current behaviour might not be the desired one for the final version, we can change it anytime without effort.
