### PR TITLE
Used utf8 literal.

### DIFF
--- a/tests/iterator-test.cpp
+++ b/tests/iterator-test.cpp
@@ -53,7 +53,7 @@ TEST_CASE("iteration tests", "[rebol] [iterator]")
 
     SECTION("unicode string iteration")
     {
-        const char * utf8Cstr = "MetÆducation\n";
+        const char * utf8Cstr = u8"MetÆducation\n";
 
         std::wstring ws;
         for (auto wc : String{utf8Cstr})


### PR DESCRIPTION
I used an utf8 literal instead of a plain string literal. It forces implementation to produce an utf8-encoded string (instead of an implementation-defined encoding I presume. I don't remember the details). Of course, it will only produce the good result if the file is utf8-encoded too...
