### PR TITLE
Fix compile time error with Windows.

### DIFF
--- a/src/rebol-binding/rebol-hooks.cpp
+++ b/src/rebol-binding/rebol-hooks.cpp
@@ -22,16 +22,6 @@ extern "C" {
 
 extern jmp_buf * Halt_State;
 void Init_Task_Context();	// Special REBOL values per task
-
-#ifdef TO_WIN32
-    #include <windows.h>
-    // The objects file from Rebol linked into RenCpp need a
-    // variable named App_Instance for the linkage to work when
-    // built for Windows. Therefore, we provided this variable
-    // here. It does not serve any other purpose.
-    HINSTANCE App_Instance = 0;
-#endif
-
 }
 
 

--- a/src/rebol-binding/rebol-runtime.cpp
+++ b/src/rebol-binding/rebol-runtime.cpp
@@ -11,6 +11,15 @@
 extern "C" {
 #include "rebol/src/include/reb-ext.h"
 #include "rebol/src/include/reb-lib.h"
+
+#ifdef TO_WIN32
+    #include <windows.h>
+    // The objects file from Rebol linked into RenCpp need a
+    // variable named App_Instance for the linkage to work when
+    // built for Windows. Therefore, we provided this variable
+    // here. It does not serve any other purpose.
+    HINSTANCE App_Instance = 0;
+#endif
 }
 
 #ifndef MAX_PATH


### PR DESCRIPTION
`TCHAR` needs `<windows.h>`. I moved the only include of `<windows.h>` from rebol-hooks.cpp to rebol-runtime.cpp since it was only needed to declare `App_Instance` and we don't really care in which .cpp file `App_Instance` is declared since it's only here for linkage to work. I thought that including `<windows.h>` only once and not twice would be better so I moved `App_Instance` to the file where `TCHAR` was also needed.
