### PR TITLE
CppCheck suggestions.

### DIFF
--- a/include/rencpp/error.hpp
+++ b/include/rencpp/error.hpp
@@ -20,7 +20,6 @@
 //
 
 #include <exception>
-#include <sstream>
 
 #include "value.hpp"
 
@@ -160,11 +159,11 @@ private:
 
 public:
     exit_command (int code) :
-        codeValue (code)
+        codeValue (code),
+        whatString ("ren::exit_command("
+                    + std::to_string(code)
+                    + ")")
     {
-        std::ostringstream ss;
-        ss << "ren::exit_command(" << code << ")";
-        whatString = ss.str();
     }
 
     char const * what() const noexcept override {

--- a/include/rencpp/function.hpp
+++ b/include/rencpp/function.hpp
@@ -535,7 +535,7 @@ private:
             // string into a cell, and tell the ren runtime that's what
             // happened.  For now we just rethrow
 
-            throw e;
+            throw;
         }
         catch (...) {
 


### PR DESCRIPTION
I ran CppCheck and applied some of its suggestions:
- Use a bare `throw;` to rethrow an exception instead of `throw e;` to avoid a useless copy.
- Get rid of the `std::ostringstream` to initialize `whatString`. Use `std::to_string` instead.

There were many other suggestions but most of them can be discussed. This branch only contains the unquestionable improvements.
