### PR TITLE
Fixed build without Qt.

### DIFF
--- a/include/rencpp/value.hpp
+++ b/include/rencpp/value.hpp
@@ -779,7 +779,7 @@ namespace internal {
 class Loadable : protected Value {
 private:
     friend class Value;
-#if REN_CLASSLIB_STD == 1
+#if REN_CLASSLIB_QT == 1
     // if we are constructing this Loadable from a QString, we need its
     // utf8 representation...unfortunately there is no QString::data()
     // equivalent.  We must use QString::toUtf8() and hold onto the byte


### PR DESCRIPTION
I think that there was a confusion regarding the `REN_CLASSLIB_` to check. Isn't there a way to make Travis check whether RenCpp can also build alone without Qt?
