### PR TITLE
 Fix #19 Up/down arrows don't perform text navigation with multi-line, pasted text

### DIFF
--- a/examples/workbench/replpad.h
+++ b/examples/workbench/replpad.h
@@ -203,6 +203,7 @@ protected slots:
 protected:
     void clearCurrentInput();
     void containInputSelection();
+    void switchToMultiline();
 
 
 protected:


### PR DESCRIPTION
Note that pasting with context menu still doesn't work.
