### PR TITLE
Use CHECK_THROWS_AS when possible.

### DIFF
--- a/tests/apply-test.cpp
+++ b/tests/apply-test.cpp
@@ -18,29 +18,20 @@ TEST_CASE("apply test", "[rebol] [apply]")
 
     SECTION("set-word failure")
     {
-        bool caught = false;
-        try {
-            SetWord {"w"}(10, 20);
-        }
-        catch (evaluation_error const & e) {
-            caught = true;
-        }
-
-        CHECK(caught);
+        CHECK_THROWS_AS(
+            SetWord {"w"}(10, 20),
+            evaluation_error
+        );
     }
 
     SECTION("none failure")
     {
-        bool caught = false;
-        try {
-            // technical note: explicit none(arg1, arg2...) is now illegal
-            Value value = none;
-            value.apply(10);
-        }
-        catch (evaluation_error const & e) {
-            caught = true;
-        }
+        // technical note: explicit none(arg1, arg2...) is now illegal
+        Value value = none;
 
-        CHECK(caught);
+        CHECK_THROWS_AS(
+            value.apply(10),
+            evaluation_error
+        );
     }
 }

--- a/tests/cast-test.cpp
+++ b/tests/cast-test.cpp
@@ -29,22 +29,13 @@ TEST_CASE("cast test", "[rebol] [cast]")
     {
         Value value = Integer {20};
 
-        bool caught = false;
-
-        try {
-            // You can't treat the bits of an Integer as Float in the Rebol or
-            // Red world...C++ *could* have a cast operator for it.  See:
-            //
-            //     https://github.com/hostilefork/rencpp/issues/7
-
-            Float illegalFloat = static_cast<Float>(value);
-
-            // that should have thrown an exception...shouldn't get here...
-        }
-        catch (std::bad_cast const & e) {
-            caught = true;
-        }
-
-        CHECK(caught);
+        // You can't treat the bits of an Integer as Float in the Rebol or
+        // Red world...C++ *could* have a cast operator for it.  See:
+        //
+        //     https://github.com/hostilefork/rencpp/issues/7
+        CHECK_THROWS_AS(
+            static_cast<Float>(value),
+            std::bad_cast
+        );
     }
 }

--- a/tests/literals-test.cpp
+++ b/tests/literals-test.cpp
@@ -68,13 +68,9 @@ TEST_CASE("literals construction", "[rebol] [literals]")
 
     SECTION("string construction error")
     {
-        bool caught = false;
-        try {
-            runtime("{Hello");
-        }
-        catch (load_error const & e) {
-            caught = true;
-        }
-        CHECK(caught);
+        CHECK_THROWS_AS(
+            runtime("{Hello"),
+            load_error
+        );
     }
 }


### PR DESCRIPTION
I decided to replace the complex `try` .. `catch` blocks in the tests by Catch's dedicated `CHECK_THROWS_AS`. That said, I don't know whether we care about _what_ is thrown. Ifw e don't care about the exception type and just want to make sur that it throw, then we can use the simpler `CHECK_THROWS` instead.
